### PR TITLE
Fixed wrongly decoded TAR archive headers with PHP 5.5

### DIFF
--- a/src/tar/headers/ustar.php
+++ b/src/tar/headers/ustar.php
@@ -163,7 +163,8 @@ class ezcArchiveUstarHeader extends ezcArchiveV7Header
             parent::__construct( $file );
 
             // Decode the rest.
-            $decoded = unpack( "@257/a6magic/a2version/a32userName/a32groupName/a8deviceMajorNumber/a8deviceMinorNumber/a155filePrefix", $file->current() );
+            $formatCode = version_compare( PHP_VERSION, '5.5.0', '<' ) ? 'a' : 'Z';
+            $decoded = unpack( "@257/{$formatCode}6magic/{$formatCode}2version/{$formatCode}32userName/{$formatCode}32groupName/{$formatCode}8deviceMajorNumber/{$formatCode}8deviceMinorNumber/{$formatCode}155filePrefix", $file->current() );
 
             // Append the decoded array to the header.
             $this->properties = array_merge( $this->properties, $decoded );

--- a/src/tar/headers/v7.php
+++ b/src/tar/headers/v7.php
@@ -193,15 +193,16 @@ class ezcArchiveV7Header
 
         if ( !is_null( $file ) )
         {
-            $this->properties = unpack ( "a100fileName/".
-                                         "a8fileMode/".
-                                         "a8userId/".
-                                         "a8groupId/".
-                                         "a12fileSize/".
-                                         "a12modificationTime/".
-                                         "a8checksum/".
-                                         "a1type/".
-                                         "a100linkName", $file->current() );
+            $formatCode = version_compare( PHP_VERSION, '5.5.0', '<' ) ? 'a' : 'Z';
+            $this->properties = unpack( "{$formatCode}100fileName/".
+                                        "{$formatCode}8fileMode/".
+                                        "{$formatCode}8userId/".
+                                        "{$formatCode}8groupId/".
+                                        "{$formatCode}12fileSize/".
+                                        "{$formatCode}12modificationTime/".
+                                        "{$formatCode}8checksum/".
+                                        "{$formatCode}1type/".
+                                        "{$formatCode}100linkName", $file->current() );
 
             $this->properties["userId"]   = octdec( $this->properties["userId"] );
             $this->properties["groupId"]  = octdec( $this->properties["groupId"] );


### PR DESCRIPTION
In PHP 5.5, TAR archive are not correctly handled any more.
This is due to a BC break in `unpack()` function in PHP 5.5.0. Now `a` format code retains trailing `NULL` bytes. We need to use `Z` format code to get the old behavior which is needed here.
