### PR TITLE
removed unused line

### DIFF
--- a/src/file/block_file.php
+++ b/src/file/block_file.php
@@ -363,7 +363,6 @@ class ezcArchiveBlockFile extends ezcArchiveFile
         // Switch write mode, if needed.
         $this->switchWriteMode();
 
-        $dataLength = sizeof( $data );
         $length = $this->writeBytes( $data );
 
         if ( ( $mod = ( $length % $this->blockSize ) ) > 0 )


### PR DESCRIPTION
The assigned variable has no effective use, and indeed [generates an error in PHP 7.2](http://php.net/manual/en/migration72.incompatible.php#migration72.incompatible.warn-on-non-countable-types).